### PR TITLE
Add sudo sandwich replier

### DIFF
--- a/src/main/scala/tshrdlu/twitter/Bot.scala
+++ b/src/main/scala/tshrdlu/twitter/Bot.scala
@@ -72,6 +72,7 @@ class Bot extends Actor with ActorLogging {
   val bigramReplier = context.actorOf(Props[BigramReplier], name = "BigramReplier")
   val luceneReplier = context.actorOf(Props[LuceneReplier], name = "LuceneReplier")
   val topicModelReplier = context.actorOf(Props[TopicModelReplier], name = "TopicModelReplier")
+  val sudoReplier = context.actorOf(Props[SudoReplier], name = "SudoReplier")
 
   override def preStart {
     replierManager ! RegisterReplier(streamReplier)
@@ -80,6 +81,7 @@ class Bot extends Actor with ActorLogging {
     replierManager ! RegisterReplier(bigramReplier)
     replierManager ! RegisterReplier(luceneReplier)
     replierManager ! RegisterReplier(topicModelReplier)
+    replierManager ! RegisterReplier(sudoReplier)
   }
 
   def receive = {

--- a/src/main/scala/tshrdlu/twitter/Replier.scala
+++ b/src/main/scala/tshrdlu/twitter/Replier.scala
@@ -390,3 +390,29 @@ class LuceneReplier extends BaseReplier {
 
 }
 
+
+/**
+ * An actor that responds to requests to make sandwiches.
+ *
+ * @see <a href="http://xkcd.com/149/">http://xkcd.com/149/</a>
+ */
+class SudoReplier extends BaseReplier {
+  import scala.concurrent.Future
+  import context.dispatcher
+
+  lazy val MakeSandwichRE = """(?i)(?:.*(\bsudo\b))?.*\bmake (?:me )?an?\b.*\bsandwich\b.*""".r
+
+  def getReplies(status: Status, maxLength: Int = 140): Future[Seq[String]] = {
+    log.info("Checking for sandwich requests")
+    val text = TwitterRegex.stripLeadMention(status.getText)
+    val replies: Seq[String] = Seq(text) collect {
+      case MakeSandwichRE(sudo) => {
+        Option(sudo) match {
+          case Some(_) => "Okay."
+          case None => "What? Make it yourself."
+        }
+      }
+    }
+    Future(replies.filter(_.length <= maxLength))
+  }
+}


### PR DESCRIPTION
Replies to requests to make sandwiches as in the XKCD cartoon:
http://xkcd.com/149/

Unfortunately, a user will be unlikely to have the same conversation
with the bot as in the cartoon because the current Akka-based bot picks
among candidate replies randomly.
